### PR TITLE
Added a SwapCase trait for chars and fixed #8

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -169,4 +169,14 @@ mod tests {
             assert_eq!(got, should_be);
         }
     }
+
+    #[test]
+    fn swapping_case() {
+        let inputs = [('a', 'A'), ('m', 'M'), ('$', '$'), ('z', 'Z'), ('s', 'S')];
+
+        for &(left, right) in &inputs {
+            assert_eq!(left.uppercase(), right);
+            assert_eq!(right.lowercase(), left);
+        }
+    }
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -28,6 +28,33 @@ impl MaybeAlphabetic for char {
     }
 }
 
+pub trait SwapCase {
+    fn uppercase(&self) -> Self;
+    fn lowercase(&self) -> Self;
+}
+
+impl SwapCase for char {
+    fn uppercase(&self) -> Self {
+        match *self {
+            'a'...'z' => {
+                let diff = 'a' as u8 - 'A' as u8;
+                (*self as u8 - diff) as Self
+            }
+            other => other,
+        }
+    }
+
+    fn lowercase(&self) -> Self {
+        match *self {
+            'A'...'Z' => {
+                let diff = 'a' as u8 - 'A' as u8;
+                (*self as u8 + diff) as Self
+            }
+            other => other,
+        }
+    }
+}
+
 
 #[cfg(feature = "nightly")]
 pub mod lines {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -150,7 +150,7 @@ impl<I> Tokenizer<I>
     }
 
     fn tokenize_alpha(&mut self, first: char, span: Span) -> Result<Token> {
-        let kind = match first {
+        let kind = match first.uppercase() {
             'G' => TokenKind::G,
             'M' => TokenKind::M,
             'T' => TokenKind::T,
@@ -169,7 +169,7 @@ impl<I> Tokenizer<I>
             'J' => TokenKind::J,
             'E' => TokenKind::E,
 
-            other => TokenKind::Other(other),
+            other => TokenKind::Other(first),
         };
 
         Ok(Token { kind, span })
@@ -393,5 +393,13 @@ mod tests {
         let mut tokenizer = Tokenizer::new(src.chars());
         tokenizer.skip_to_end_of_line();
         assert_eq!(tokenizer.src.next(), Some('7'));
+    }
+
+    #[test]
+    fn case_insensitive_tokens() {
+        let lower = Tokenizer::new("g".chars()).next();
+        let upper = Tokenizer::new("G".chars()).next();
+
+        assert_eq!(lower, upper);
     }
 }


### PR DESCRIPTION
This makes sure that gcodes are case insensitive, while also returning the correct character when it hits a token it doesn't know (`Token::Other`).