### PR TITLE
Change error message on unknown M Code from 'G Code' to 'M Code'

### DIFF
--- a/src/high_level.rs
+++ b/src/high_level.rs
@@ -95,7 +95,7 @@ fn convert_m(number: u32, args: &[Argument]) -> Result<MCode> {
     let arg_reader = ArgumentReader::read(args);
 
     match number {
-        other => panic!("G Code not yet supported: {}", other),
+        other => panic!("M Code not yet supported: {}", other),
     }
 }
 


### PR DESCRIPTION
This clarifies the panic message when an M Code is not supported.
It changes the message from
`G Code not yet supported:`
to
`M Code not yet supported:`
when an unknown M Code is encountered.
This does not change the unsupported G Code message.