### PR TITLE
Export ParseNumberError

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -165,7 +165,7 @@ mod types;
 pub use self::parser::{ParserState, resume};
 pub use self::types::{
     BlockVisitor, CommandVisitor, ControlFlow, Diagnostics, HasDiagnostics,
-    Noop, Number, ProgramVisitor, Span, TokenType, Value,
+    Noop, Number, ParseNumberError, ProgramVisitor, Span, TokenType, Value,
 };
 
 /// Parses `src` from start to finish, driving `visitor` for each block.

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -178,9 +178,12 @@ impl Debug for Number {
     }
 }
 
+/// An error returned when parsing a number.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ParseNumberError {
+    /// Number integer parsing error.
     ParseInt(core::num::ParseIntError),
+    /// Number overflow error.
     Overflow,
 }
 


### PR DESCRIPTION
Without this the Diagnostics trait cannot be fully implemented.

Includes doc comments to pass clippy lints.